### PR TITLE
fix: Update debug logging and refine parameters for SoraCam tools

### DIFF
--- a/src/handlers/commandHandler.ts
+++ b/src/handlers/commandHandler.ts
@@ -41,7 +41,7 @@ export const handleCommand = async (command: string) => {
         break;
       }
       case CommandMethods.NotificationsInitialized: {
-        debugLog(`Notifications initialized: ${JSON.stringify(parsedCommand.params)}`);
+        debugLog(`Notifications initialized: ${JSON.stringify(parsedCommand)}`);
         break;
       }
       default: {

--- a/src/handlers/toolsMap/soraCamToolsMap.ts
+++ b/src/handlers/toolsMap/soraCamToolsMap.ts
@@ -179,15 +179,15 @@ export const soraCamToolsMap: Record<string, ToolDefinition>  = {
   },
   exportSoraCamDeviceRecordedImage: {
     fn: SoraCamService.exportSoraCamDeviceRecordedImage,
-    args: (args: any) => [args.deviceId, args.requestBody],
+    args: (args: any) => [args.deviceId, { 'time': args.time } ],
     description: 'Export still images from recorded video for a SoraCam device',
     parameters: {
       type: 'object',
       properties: {
         deviceId: { type: 'string', description: 'Device ID of the SoraCam device' },
-        requestBody: { type: 'object', description: 'Export specification' },
+        time: { type: 'number', description: 'Time to export (UNIX timestamp in ms)' },
       },
-      required: ['deviceId', 'requestBody'],
+      required: ['deviceId', 'time'],
     },
   },
   getSoraCamDeviceExportedImage: {
@@ -287,15 +287,16 @@ export const soraCamToolsMap: Record<string, ToolDefinition>  = {
   },
   exportSoraCamDeviceRecordedVideo: {
     fn: SoraCamService.exportSoraCamDeviceRecordedVideo,
-    args: (args: any) => [args.deviceId, args.requestBody],
+    args: (args: any) => [args.deviceId, {"from":args.from, "to": args.to}],
     description: 'Export recorded video for a SoraCam device',
     parameters: {
       type: 'object',
       properties: {
         deviceId: { type: 'string', description: 'Device ID of the SoraCam device' },
-        requestBody: { type: 'object', description: 'Export specification' },
+        from: { type: 'number', description: 'Start time (UNIX timestamp in ms)' },
+        to: { type: 'number', description: 'End time (UNIX timestamp in ms)' },
       },
-      required: ['deviceId', 'requestBody'],
+      required: ['deviceId', 'from', 'to'],
     },
   },
   listSoraCamDeviceAtomCamFirmwareUpdates: {


### PR DESCRIPTION
please review and comment in Japanese.
This pull request includes updates to logging and modifications to the argument structure for SoraCam tool definitions. The changes improve debugging clarity and refine the API for exporting SoraCam device data.

### Logging Improvements:
* Updated the `NotificationsInitialized` case in `handleCommand` to log the entire `parsedCommand` object instead of just its `params` property for more comprehensive debugging information. (`src/handlers/commandHandler.ts`, [src/handlers/commandHandler.tsL44-R44](diffhunk://#diff-4b6f85f2408aa620bf4897cb7a2f87fd4ee9fc30d8e36cc46bb4184e5681a5e9L44-R44))

### SoraCam Tool Definitions Refinements:
* Modified the `exportSoraCamDeviceRecordedImage` tool to replace the `requestBody` argument with a `time` parameter, updating the required fields and descriptions accordingly. (`src/handlers/toolsMap/soraCamToolsMap.ts`, [src/handlers/toolsMap/soraCamToolsMap.tsL182-R190](diffhunk://#diff-7b6d30a0d284805f71691871a194081b3ae92d270b8de1d316a3adb197b5b8fbL182-R190))
* Updated the `exportSoraCamDeviceRecordedVideo` tool to replace the `requestBody` argument with `from` and `to` parameters, reflecting the start and end times for the export. Adjusted the required fields and descriptions to match the new structure. (`src/handlers/toolsMap/soraCamToolsMap.ts`, [src/handlers/toolsMap/soraCamToolsMap.tsL290-R299](diffhunk://#diff-7b6d30a0d284805f71691871a194081b3ae92d270b8de1d316a3adb197b5b8fbL290-R299))