### PR TITLE
fix: Refine testSoralet arguments and update parameters for improved …

### DIFF
--- a/src/handlers/toolsMap/soraletToolsMap.ts
+++ b/src/handlers/toolsMap/soraletToolsMap.ts
@@ -46,15 +46,32 @@ export const soraletToolsMap: Record<string, ToolDefinition> = {
   },
   testSoralet: {
     fn: SoraletService.testSoralet,
-    args: (args: any) => [args.soraletId, args.requestBody],
+    args: (args: any) => [
+      args.soraletId,
+      {
+        'contentType': args.contentType,
+        'direction': args.direction,
+        'encodingType': args.encodingType,
+        'payload': args.payload,
+        'source': args.source,
+        'userdata': args.userdata,
+        'version': args.version,
+      }
+    ],
     description: 'Test a Soralet with arguments',
     parameters: {
       type: 'object',
       properties: {
         soraletId: { type: 'string', description: 'ID of the Soralet to test' },
-        requestBody: { type: 'object', description: 'Request body for testing the Soralet' },
+        contentType: { type: 'string', description: 'Content type of the request' },
+        direction: { type: 'string', description: 'Direction of the Soralet, uplink or downlink' },
+        encodingType: { type: 'string', description: 'Encoding type of the request, binary or text' },
+        payload: { type: 'string', description: 'Payload for the Soralet' },
+        source: { type: 'object', description: 'Source of the Soralet' },
+        userdata: { type: 'string', description: 'User data for the Soralet' },
+        version: { type: 'string', description: 'Version of the Soralet' },
       },
-      required: ['soraletId', 'requestBody'],
+      required: ['soraletId', 'contentType', 'direction', 'encodingType', 'payload', 'source', 'version'],
     },
   },
   listSoraletVersions: {


### PR DESCRIPTION
please review and comment in Japanese.
This pull request updates the `testSoralet` tool definition in `soraletToolsMap` to enhance the structure and detail of its arguments and parameters. The most significant change involves replacing the `requestBody` argument with a more granular set of fields, improving clarity and flexibility when testing Soralets.

### Changes to `testSoralet` tool definition:

* Updated the `args` function to construct a detailed object containing fields like `contentType`, `direction`, `encodingType`, `payload`, `source`, `userdata`, and `version`, replacing the previous single `requestBody` object.
* Expanded the `parameters` section to define individual properties for the new fields, each with a description, and updated the `required` list to include these new fields.
