### PR TITLE
Add data entry tools map

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,9 @@ The service classes for calling all APIs(as of April 15, 2025) are located in [s
 - **listSoraCamDeviceImageExports**: Retrieve a list of image export statuses for all SoraCam devices.
 - **listSoraCamDeviceVideoExports**: Retrieve a list of video export statuses for all SoraCam devices.
 - **listSoraCamLicensePacks**: Retrieve a list of license packs for SoraCam.
+
+## DataEntryService Tools
+
+- **getDataEntries**: Retrieve a list of data entries from a specific resource.
+- **getDataEntry**: Retrieve details of a specific data entry by resource ID and timestamp.
+- **listDataSourceResources**: List all data source resources for the operator.

--- a/src/handlers/toolsMap/dataEntryToolsMap.ts
+++ b/src/handlers/toolsMap/dataEntryToolsMap.ts
@@ -1,0 +1,78 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { DataEntryService } from '../../generated/services/DataEntryService';
+import { ToolDefinition } from './index';
+
+export const dataEntryToolsMap: Record<string, ToolDefinition> = {
+  getDataEntries: {
+    fn: DataEntryService.getDataEntries,
+    args: (args: any) => [
+      args.resourceType,
+      args.resourceId,
+      args.time,
+    ],
+    description: 'Retrieve a list of data entries from a specific resource',
+    parameters: {
+      type: 'object',
+      properties: {
+        resourceType: {
+          type: 'string',
+          description: 'Type of the data source resource',
+          enum: ['Subscriber', 'LoraDevice', 'Sim', 'SigfoxDevice', 'Device', 'SoraCam'],
+        },
+        resourceId: { type: 'string', description: 'ID of the data source resource' },
+        from: { type: 'number', description: 'Start of the time range (UNIX timestamp in ms)' },
+        to: { type: 'number', description: 'End of the time range (UNIX timestamp in ms)' },
+        sort: {
+          type: 'string',
+          description: 'Sort order',
+          enum: ['desc', 'asc'],
+        },
+        limit: { type: 'number', description: 'Maximum number of data entries to retrieve' },
+        lastEvaluatedKey: {
+          type: 'string',
+          description: 'Key of the last evaluated data entry for pagination',
+        },
+      },
+      required: ['resourceType', 'resourceId'],
+    },
+  },
+  getDataEntry: {
+    fn: DataEntryService.getDataEntry,
+    args: (args: any) => [args.resourceType, args.resourceId, args.time],
+    description: 'Retrieve details of a specific data entry by resource ID and timestamp',
+    parameters: {
+      type: 'object',
+      properties: {
+        resourceType: {
+          type: 'string',
+          description: 'Type of the data source resource',
+          enum: ['Subscriber', 'LoraDevice', 'Sim', 'SigfoxDevice', 'Device', 'SoraCam'],
+        },
+        resourceId: { type: 'string', description: 'ID of the data source resource' },
+        time: { type: 'number', description: 'Timestamp of the data entry to retrieve (UNIX timestamp in ms)' },
+      },
+      required: ['resourceType', 'resourceId', 'time'],
+    },
+  },
+  listDataSourceResources: {
+    fn: DataEntryService.listDataSourceResources,
+    args: (args: any) => [args.resourceType, args.limit, args.lastEvaluatedKey],
+    description: 'List all data source resources for the operator which can be used in the data entry',
+    parameters: {
+      type: 'object',
+      properties: {
+        resourceType: {
+          type: 'string',
+          description: 'Type of the data source resource',
+          enum: ['Subscriber', 'LoraDevice', 'Sim', 'SigfoxDevice', 'Device', 'SoraCam'],
+        },
+        limit: { type: 'number', description: 'Maximum number of resources to retrieve' },
+        lastEvaluatedKey: {
+          type: 'string',
+          description: 'Key of the last evaluated resource for pagination',
+        },
+      },
+      required: [],
+    },
+  },
+};

--- a/src/handlers/toolsMap/index.ts
+++ b/src/handlers/toolsMap/index.ts
@@ -7,6 +7,7 @@ import * as logToolsMap from './logToolsMap';
 import * as orderToolsMap from './orderToolsMap';
 import * as soraCamToolsMap from './soraCamToolsMap';
 import * as soraletToolsMap from './soraletToolsMap';
+import * as dataEntryToolsMap from './dataEntryToolsMap';
 
 export type ToolDefinition = {
   fn: (...args: any[]) => Promise<any>;
@@ -24,4 +25,5 @@ export const toolsMap: Record<string, ToolDefinition> = {
   ...Object.values(orderToolsMap).reduce((acc, curr) => ({ ...acc, ...curr }), {}),
   ...Object.values(soraCamToolsMap).reduce((acc, curr) => ({ ...acc, ...curr }), {}),
   ...Object.values(soraletToolsMap).reduce((acc, curr) => ({ ...acc, ...curr }), {}),
+  ...Object.values(dataEntryToolsMap).reduce((acc, curr) => ({ ...acc, ...curr }), {}),
 };


### PR DESCRIPTION
please review and comment in Japanese.

This pull request introduces a new `DataEntryService` module, which includes tools for managing data entries and resources. The changes involve updating the documentation, adding a new tools map for the `DataEntryService`, and integrating it into the existing tools map structure.

### Documentation Updates:
* Added a new section, "DataEntryService Tools," to the `README.md` file, documenting the `getDataEntries`, `getDataEntry`, and `listDataSourceResources` APIs.

### New Tools Map:
* Created a new file `src/handlers/toolsMap/dataEntryToolsMap.ts` to define the `dataEntryToolsMap`, which includes tool definitions for `getDataEntries`, `getDataEntry`, and `listDataSourceResources`. Each tool is mapped to its corresponding function in the `DataEntryService` and includes parameter validation schemas.

### Integration with Existing Tools Map:
* Updated `src/handlers/toolsMap/index.ts` to import the `dataEntryToolsMap` and integrate its tools into the main `toolsMap` object. [[1]](diffhunk://#diff-224ff499202a720bd07c25826db3c19677df7095c864365442b198c20a1f647cR10) [[2]](diffhunk://#diff-224ff499202a720bd07c25826db3c19677df7095c864365442b198c20a1f647cR28)
